### PR TITLE
usb1: Add __hash__ and __eq__ to USBDevice

### DIFF
--- a/usb1.py
+++ b/usb1.py
@@ -1526,6 +1526,18 @@ class USBDevice(object):
         return USBConfiguration(self.__context,
             self.__configuration_descriptor_list[index])
 
+    def __key(self):
+        return (id(self.__context), self.getBusNumber(),
+                self.getDeviceAddress(), self.getVendorID(),
+                self.getProductID())
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(x, y):
+        return type(x) == type(y) and (
+            x.device_p == y.device_p or x.__key() == y.__key())
+
     def iterConfigurations(self):
         context = self.__context
         for config in self.__configuration_descriptor_list:


### PR DESCRIPTION
Hi,

Thanks for your work on this Python wrapper, it's really nice to work with.

This is just a small addition that I found useful (commit message follows).

Cheers,

Angus

***

This wouldn't make sense for device handles, but for USBDevice instances
if they share a context and the bus/device numbers and vid/pid match,
they're equal and interchangeable.

This is handy for keeping sets of USB devices around, etc.