### PR TITLE
Update libusb API reference link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -330,4 +330,4 @@ values for ``data`` parameter.
 
 .. _libusbx: http://libusb.info/
 
-.. _libusb1.0 documentation: http://libusb.sourceforge.net/api-1.0/
+.. _libusb1.0 documentation: http://libusb.org/static/api-1.0/


### PR DESCRIPTION
libusb is no longer hosted on SourceForge.