### PR TITLE
Cast libusb pollfd callbacks from null pointer to proper type

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -2086,7 +2086,7 @@ class USBContext(object):
     __removed_cb = None
     __poll_cb_user_data = None
     __libusb_set_pollfd_notifiers = libusb1.libusb_set_pollfd_notifiers
-    __null_pointer = POINTER(None)
+    __null_pointer = c_void_p()
     __KeyError = KeyError
     __auto_open = True
 
@@ -2385,7 +2385,9 @@ class USBContext(object):
         self.__removed_cb = removed_cb
         self.__poll_cb_user_data = user_data
         self.__libusb_set_pollfd_notifiers(
-            self.__context_p, added_cb, removed_cb, user_data)
+            self.__context_p,
+            cast(added_cb, libusb1.libusb_pollfd_added_cb_p),
+            cast(removed_cb, libusb1.libusb_pollfd_removed_cb_p), user_data)
 
     @_validContext
     def getNextTimeout(self):


### PR DESCRIPTION
This avoids an exception (sometimes a segfault) during Python process exit
with a signature like the following:

```
Exception ignored in: <bound method USBPoller.__del__ of <usb1.USBPoller object at 0x7f7700e4eda0>>
Traceback (most recent call last):
  File "/home/whitequark/.local/lib/python3.6/site-packages/usb1/__init__.py", line 1081, in __del__
  File "/home/whitequark/.local/lib/python3.6/site-packages/usb1/__init__.py", line 2127, in wrapper
  File "/home/whitequark/.local/lib/python3.6/site-packages/usb1/__init__.py", line 2387, in setPollFDNotifiers
ctypes.ArgumentError: argument 2: <class 'TypeError'>: expected CFunctionType instance instead of _ctypes.PyCSimpleType
```

I'm not sure how this ever worked--a ctypes change, perhaps? In any case, the `POINTER(None)` needs to be called before use, and cast to the callback type.