### PR TITLE
Fix getting of extra descriptors

### DIFF
--- a/usb1/libusb1.py
+++ b/usb1/libusb1.py
@@ -1103,7 +1103,7 @@ def get_extra(descriptor):
     result = []
     extra_length = descriptor.extra_length
     if extra_length:
-        extra = buffer_at(descriptor.extra.value, extra_length)
+        extra = buffer_at(descriptor.extra, extra_length)
         append = result.append
         while extra:
             length = _string_item_to_int(extra[0])


### PR DESCRIPTION
Also add a test to check that getting of extra descriptors works
(requires a USB device with extra descriptors, such as a UVC webcam,
which has at least one InterfaceAssociation descriptor).