### PR TITLE
Improve a sketchy implementation of free()

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -48,7 +48,7 @@ subclassing USBError.
 from __future__ import division, absolute_import
 from ctypes import byref, c_int, sizeof, POINTER, \
     cast, c_uint8, c_uint16, c_ubyte, c_void_p, cdll, addressof, \
-    c_char
+    c_char, pythonapi
 from ctypes.util import find_library
 import sys
 import threading
@@ -205,14 +205,7 @@ else:
 CONTROL_SETUP = BYTE * CONTROL_SETUP_SIZE
 # pylint: enable=undefined-variable
 
-__libc_name = find_library('c')
-if __libc_name is None:
-    # Of course, will leak memory.
-    # Should we warn user ? How ?
-    _free = lambda x: None
-else:
-    _free = getattr(cdll, __libc_name).free
-del __libc_name
+_free = pythonapi.free
 
 try:
     WeakSet = weakref.WeakSet

--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -48,7 +48,7 @@ subclassing USBError.
 from __future__ import division, absolute_import
 from ctypes import byref, c_int, sizeof, POINTER, \
     cast, c_uint8, c_uint16, c_ubyte, c_void_p, cdll, addressof, \
-    c_char, pythonapi
+    c_char
 from ctypes.util import find_library
 import sys
 import threading
@@ -204,8 +204,6 @@ else:
 # pylint: disable=undefined-variable
 CONTROL_SETUP = BYTE * CONTROL_SETUP_SIZE
 # pylint: enable=undefined-variable
-
-_free = pythonapi.free
 
 try:
     WeakSet = weakref.WeakSet
@@ -2411,7 +2409,7 @@ class USBContext(object):
                 ))
                 fd_index += 1
         finally:
-            _free(pollfd_p_p)
+            libusb1.libusb_free_pollfds(pollfd_p_p)
         return result
 
     @_validContext

--- a/usb1/libusb1.py
+++ b/usb1/libusb1.py
@@ -30,7 +30,7 @@ from ctypes import (
     c_short, c_int, c_uint, c_size_t, c_long,
     c_uint8, c_uint16, c_uint32,
     c_void_p, c_char_p, py_object, pointer, c_char,
-    c_ssize_t,
+    c_ssize_t, pythonapi
 )
 import ctypes.util
 import platform
@@ -1249,6 +1249,16 @@ libusb_set_pollfd_notifiers.argtypes = [libusb_context_p,
                                         libusb_pollfd_added_cb_p,
                                         libusb_pollfd_removed_cb_p, py_object]
 libusb_set_pollfd_notifiers.restype = None
+try:
+    #void libusb_get_pollfds(const struct libusb_pollfd **);
+    libusb_free_pollfds = libusb.libusb_free_pollfds
+    libusb_free_pollfds.argtypes = [libusb_pollfd_p_p]
+    libusb_free_pollfds.restype = None
+except AttributeError:
+    # Not a safe replacement in general, but the versions of libusb that lack
+    # libusb_free_pollfds() only provide that function on *nix, where
+    # Python's free() and libusb's free() are ~always the same anyways.
+    libusb_free_pollfds = pythonapi.free
 
 #typedef int libusb_hotplug_callback_handle;
 libusb_hotplug_callback_handle = c_int


### PR DESCRIPTION
It's not necessary to import anything to get `free` since it is (dynamically) linked into the Python executable and can be found in it. We could open a `ctypes.CDLL(None)` (equivalent to `dlopen(NULL)`, but a more idiomatic `ctypes.pythonapi` import works the same:
```
>>> import ctypes
>>> ctypes.pythonapi
<PyDLL 'None', handle 7fd37eb34190 at 0x7fd37dd35e10>
>>> ctypes.pythonapi.free
<_FuncPtr object at 0x7fd37e021750>
```

Of course, well-designed C libraries provide functions to free any memory they allocate. libusb does, too, since 1.0.20, so use that if possible (but keep the workaround so we don't start leaking memory where we didn't before).