### PR TITLE
Add a script for building Windows binary wheels

### DIFF
--- a/buildWheels.sh
+++ b/buildWheels.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -ex
+
+PYTHON=${PYTHON:-python}
+VERSION=${VERSION:-1.0.23}
+
+cd $(dirname $0)
+wget -nc https://github.com/libusb/libusb/releases/download/v${VERSION}/libusb-${VERSION}.7z -P build
+sha256sum build/libusb-${VERSION}.7z
+
+# Windows x86
+mkdir -p build/win32
+7z e -aoa -obuild/win32 build/libusb-${VERSION}.7z MS32/dll/libusb-1.0.dll
+sha256sum build/win32/libusb-1.0.dll
+LIBUSB_BINARY=build/win32/libusb-1.0.dll ${PYTHON} setup.py bdist_wheel --plat-name win32
+
+# Windows x86_64
+mkdir -p build/win_amd64
+7z e -aoa -obuild/win_amd64 build/libusb-${VERSION}.7z MS64/dll/libusb-1.0.dll
+sha256sum build/win_amd64/libusb-1.0.dll
+LIBUSB_BINARY=build/win_amd64/libusb-1.0.dll ${PYTHON} setup.py bdist_wheel --plat-name win_amd64
+
+# arch-independent (uses OS installation)
+${PYTHON} setup.py bdist_wheel --plat-name any

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,16 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 from setuptools import setup
+from distutils.command.install import install
 from codecs import open
 import os
 import versioneer
+
+class install(install):
+    def run(self):
+        super().run()
+        if os.getenv('LIBUSB_BINARY'):
+            self.copy_file(os.getenv('LIBUSB_BINARY'), os.path.join(self.install_lib, 'usb1'))
 
 long_description = open(
     os.path.join(os.path.dirname(__file__), 'README.rst'),
@@ -29,7 +36,10 @@ setup(
     long_description='.. contents::\n\n' + long_description,
     keywords='usb libusb',
     version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(),
+    cmdclass={
+        'install': install,
+        **versioneer.get_cmdclass(),
+    },
     author='Vincent Pelletier',
     author_email='plr.vincent@gmail.com',
     url='http://github.com/vpelletier/python-libusb1',

--- a/usb1/libusb1.py
+++ b/usb1/libusb1.py
@@ -147,8 +147,14 @@ def _loadLibrary():
     else:
         dll_loader = ctypes.CDLL
         suffix = system == 'Darwin' and '.dylib' or '.so'
+    filename = 'libusb-1.0' + suffix
+    # If this is a binary wheel, use the integrated libusb unconditionally.
+    # To use the libusb from the Python installation or the OS, install from sdist:
+    #   > pip install --no-binary :all: libusb1
+    if os.path.exists(os.path.join(os.path.dirname(__file__), filename)):
+        filename = os.path.join(os.path.dirname(__file__), filename)
     try:
-        return dll_loader('libusb-1.0' + suffix, use_errno=True, use_last_error=True)
+        return dll_loader(filename, use_errno=True, use_last_error=True)
     except OSError:
         libusb_path = None
         base_name = 'usb-1.0'


### PR DESCRIPTION
The wheels contain the official libusb1 binaries, so the additional risk from shipping them is negligible.

See #33.