### PR TITLE
Fix destruction of hotplug callbacks as a part of context teardown

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -2299,7 +2299,8 @@ class USBContext(object):
     def _exit(self):
         context_p = self.__context_p
         if context_p:
-            for handle in self.__hotplug_callback_dict.keys():
+            while self.__hotplug_callback_dict:
+                handle = next(iter(self.__hotplug_callback_dict))
                 self.hotplugDeregisterCallback(handle)
             pop = self.__close_set.pop
             while True:


### PR DESCRIPTION
Before this commit, the callback would delete itself from the list,
causing an exception:

```
  File ".../glasgow/device/hardware.py", line 207, in close
    self.usb_context.close()
  File ".../python-libusb1/build/lib/usb1/__init__.py", line 2288, in close
    self._exit()
  File ".../python-libusb1/build/lib/usb1/__init__.py", line 2296, in _exit
    for handle in self.__hotplug_callback_dict.keys():
RuntimeError: dictionary changed size during iteration
```