### PR TITLE
Use notify_all instead of notifyAll method that was deprecated in Python 3.10

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -2215,7 +2215,7 @@ class USBContext(object):
                 with self.__context_cond:
                     self.__context_refcount -= 1
                     if not self.__context_refcount:
-                        self.__context_cond.notifyAll()
+                        self.__context_cond.notify_all()
         if inspect.isgeneratorfunction(func):
             def wrapper(self, *args, **kw):
                 with refcount(self):
@@ -2293,7 +2293,7 @@ class USBContext(object):
                 self.__context_cond.wait()
             self._exit()
         finally:
-            self.__context_cond.notifyAll()
+            self.__context_cond.notify_all()
             self.__context_cond.release()
 
     def _exit(self):


### PR DESCRIPTION
Fixes #70 