### PR TITLE
add support for LIBUSB_SPEED_SUPER_PLUS for libusb 1.0.24+

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -2022,6 +2022,7 @@ class USBDevice(object):
             SPEED_FULL
             SPEED_HIGH
             SPEED_SUPER
+            SPEED_SUPER_PLUS
         """
         return libusb1.libusb_get_device_speed(self.device_p)
 

--- a/usb1/libusb1.py
+++ b/usb1/libusb1.py
@@ -564,6 +564,8 @@ libusb_speed = Enum({
     'LIBUSB_SPEED_HIGH': 3,
     # The device is operating at super speed (5000MBit/s).
     'LIBUSB_SPEED_SUPER': 4,
+    # The device is operating at super speed plus (10000MBit/s)
+    'LIBUSB_SPEED_SUPER_PLUS': 5,
 })
 
 libusb_supported_speed = Enum({


### PR DESCRIPTION
As [libusb 1.0.24](https://libusb.sourceforge.io/api-1.0/group__libusb__dev.html) adds a new enum `LIBUSB_SPEED_SUPER_PLUS `, update the python binding accordingly.