### PR TITLE
usb1: Clean up poll fd finalizer

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -2424,21 +2424,23 @@ class USBContext:
         if not self.__has_pollfd_finalizer:
             self.__has_pollfd_finalizer = True
             try:
-                self.__registerFinalizer(
-                    handle=id(self),
-                    finalizer=weakref.finalize(
-                        self,
-                        self.__finalizePollFDNotifiers, # Note: staticmethod
-                        context_p=self.__context_p,
-                        libusb_set_pollfd_notifiers=libusb1.libusb_set_pollfd_notifiers,
-                    ),
+                finalizer_handle = id(self)
+                finalizer_dict = self.__finalizer_dict
+                finalizer = weakref.finalize(
+                    self,
+                    self.__finalizePollFDNotifiers, # Note: staticmethod
+                    context_p=self.__context_p,
+                    unregisterFinalizer=lambda: finalizer_dict.pop(finalizer_handle),
+                    libusb_set_pollfd_notifiers=libusb1.libusb_set_pollfd_notifiers,
                 )
+                self.__registerFinalizer(finalizer_handle, finalizer)
             except ValueError: # Already registered
                 pass
 
     @staticmethod
     def __finalizePollFDNotifiers(
         context_p,
+        unregisterFinalizer,
         libusb_set_pollfd_notifiers,
 
         null_pointer=_null_pointer,
@@ -2451,6 +2453,7 @@ class USBContext:
             removed_cb_p,
             null_pointer,
         )
+        unregisterFinalizer()
 
     @_validContext
     def getNextTimeout(self):


### PR DESCRIPTION
There is a bug in `usb1.USBContext.setPollFDNotifiers()` that makes it impossible to be used correctly. During cleanup you always hit an assert.

Minimal repro:
```sh
# minimal setup
python3 -m virtualenv libusb-repro-venv
. libusb-repro-venv/bin/activate
python3 -m pip install libusb1
# actual repro
python3 - <<'EOS'
from usb1 import USBContext
with USBContext() as ctx:
    ctx.setPollFDNotifiers()
EOS
```

Resulting stacktrace:
```
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
  File "/home/maxtruxa/libusb-repro-venv/lib/python3.9/site-packages/usb1/__init__.py", line 2147, in __exit__
    self.close()
  File "/home/maxtruxa/libusb-repro-venv/lib/python3.9/site-packages/usb1/__init__.py", line 2203, in close
    self.__close()
  File "/usr/lib/python3.9/weakref.py", line 580, in __call__
    return info.func(*info.args, **(info.kwargs or {}))
  File "/home/maxtruxa/libusb-repro-venv/lib/python3.9/site-packages/usb1/__init__.py", line 2235, in ___close
    assert handle not in finalizer_dict
AssertionError
```

`setPollFDNotifiers()` registers a finalizer, but the finalizer does not remove itself from the `finalizer_dict`. This PR resolves the issue following the same pattern that was used in `USBTranser.__init__()`, `USBDeviceHandle.__init__()` and `USBDevice.__init__()` to solve the exact same problem.