### PR TITLE
add flags set method for tansfer

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -713,6 +713,16 @@ class USBTransfer:
         transfer.buffer = cast(buff, c_void_p)
         transfer.length = sizeof(buff)
 
+    def setFlags(self, flags):
+        """
+        Set transfer flags.
+
+        flags is a bitwise or of TRANSFER_FLAGS_* constants.
+        """
+        if self.isSubmitted():
+            raise ValueError('Cannot alter a submitted transfer')
+        self.__transfer.contents.flags = flags
+
     def isSubmitted(self):
         """
         Tells if this transfer is submitted and still pending.


### PR DESCRIPTION
 This PR adds a `setFlags()` method to USBTransfer to set the `libusb_transfer.flags`