### PR TITLE
Add example for scanning the complete device tree

### DIFF
--- a/examples/scan_device_tree.py
+++ b/examples/scan_device_tree.py
@@ -1,0 +1,72 @@
+"""
+python-libusb1 device tree scan example.
+This program shows the entire tree of devices/configurations/interfaces/endpoints
+that are available on your computer.  It should be useful when interfacing with a
+new USB device (since you can easily examine what features are available on the device).
+"""
+
+import usb1
+
+def scan_device_tree():
+	with usb1.USBContext() as context:
+	    for dev in context.getDeviceIterator(skip_on_error=True):
+	        dev: usb1.USBDevice
+
+	        try:
+	            print(
+	                f"- Device: {dev.getVendorID():04x}:{dev.getProductID():04x}, {dev.getManufacturer()} {dev.getProduct()}, SerNo: {dev.getSerialNumber()}"
+	            )
+	        except usb1.USBError:
+	            print(
+	                f"- Device: {dev.getVendorID():04x}:{dev.getProductID():04x} <failed to open, on Windows this is because it does not have the WinUSB driver attached>"
+	            )
+
+	        for cfg in dev:
+	            # Note: for docs on USBConfiguration, see here: https://libusb.sourceforge.io/api-1.0/structlibusb__config__descriptor.html
+	            # Also see https://www.beyondlogic.org/usbnutshell/usb5.shtml#ConfigurationDescriptors
+	            cfg: usb1.USBConfiguration
+	            print(
+	                f"---> Cfg: Num Interfaces: {cfg.getNumInterfaces()}, Identifier: {cfg.getConfigurationValue()}, "
+	                f"Attributes: 0x{cfg.getAttributes():02x}"
+	            )
+
+	            for iface in cfg:
+	                iface: usb1.USBInterface
+
+	                for altsetting in iface:
+	                    altsetting: usb1.USBInterfaceSetting
+
+	                    # The docs for USBInterfaceSetting can be seen here:
+	                    # https://libusb.sourceforge.io/api-1.0/structlibusb__interface__descriptor.html
+	                    # For an enumeration of defined class, subclass, and protocol values, see here:
+	                    # https://www.usb.org/defined-class-codes
+
+	                    print(
+	                        f"    ---> Alternate settings: Num Endpoints: {altsetting.getNumEndpoints()}, "
+	                        f"Class and SubClass: (0x{altsetting.getClass():02x}, 0x{altsetting.getSubClass():02x}), "
+	                        f"Protocol: {altsetting.getProtocol()}"
+	                    )
+
+	                    for endpoint in altsetting:
+	                        endpoint: usb1.USBEndpoint
+
+	                        # The docs for USBEndpoint can be seen here:
+	                        # https://libusb.sourceforge.io/api-1.0/structlibusb__endpoint__descriptor.html#a111d087a09cbeded8e15eda9127e23d2
+
+	                        # Process attributes field
+	                        if endpoint.getAttributes() & 3 == 0:
+	                            ep_type = "Control"
+	                        elif endpoint.getAttributes() & 3 == 1:
+	                            ep_type = "Isochronous"
+	                        elif endpoint.getAttributes() & 3 == 2:
+	                            ep_type = "Bulk"
+	                        else:
+	                            ep_type = "Interrupt"
+
+	                        print(
+	                            f"        ---> Endpoint 0x{endpoint.getAddress():02x}: Direction: "
+	                            f"{'Dev-To-Host' if endpoint.getAddress() & 0x80 != 0 else 'Host-To-Dev'}, Type: {ep_type}"
+	                        )
+
+if __name__ == '__main__':
+    scan_device_tree()

--- a/examples/scan_device_tree.py
+++ b/examples/scan_device_tree.py
@@ -30,10 +30,12 @@ def scan_device_tree():
 	                f"Attributes: 0x{cfg.getAttributes():02x}"
 	            )
 
-	            for iface in cfg:
+	            for iface_idx, iface in enumerate(cfg):
 	                iface: usb1.USBInterface
 
-	                for altsetting in iface:
+	                print(f"    ---> Interface {iface_idx}")
+
+	                for altsetting_idx, altsetting in enumerate(iface):
 	                    altsetting: usb1.USBInterfaceSetting
 
 	                    # The docs for USBInterfaceSetting can be seen here:
@@ -42,7 +44,7 @@ def scan_device_tree():
 	                    # https://www.usb.org/defined-class-codes
 
 	                    print(
-	                        f"    ---> Alternate settings: Num Endpoints: {altsetting.getNumEndpoints()}, "
+	                        f"        ---> Alternate settings {altsetting_idx}: Num Endpoints: {altsetting.getNumEndpoints()}, "
 	                        f"Class and SubClass: (0x{altsetting.getClass():02x}, 0x{altsetting.getSubClass():02x}), "
 	                        f"Protocol: {altsetting.getProtocol()}"
 	                    )
@@ -64,9 +66,10 @@ def scan_device_tree():
 	                            ep_type = "Interrupt"
 
 	                        print(
-	                            f"        ---> Endpoint 0x{endpoint.getAddress():02x}: Direction: "
+	                            f"            ---> Endpoint 0x{endpoint.getAddress():02x}: Direction: "
 	                            f"{'Dev-To-Host' if endpoint.getAddress() & 0x80 != 0 else 'Host-To-Dev'}, Type: {ep_type}"
 	                        )
+
 
 if __name__ == '__main__':
     scan_device_tree()


### PR DESCRIPTION
Hi!  Thanks again for all your work on this library!
For my current project, I have to implement finding a USB device that might be at different VIDs and PIDs, so I need my code to look at the complete tree of configurations/interfaces/endpoints to determine where the device might be.

As part of that, I wrote this program which scans the entire USB device tree and outputs all the detected devices and their attributes.  I figured it might be useful to someone else doing something similar, so it could make sense as an example!

Let me know if there's anything I should fix or change to make it a better example!

The output from the code looks like:
```
- Device: 04b4:e010, Cypress Semiconductor Mbed CE CY7C65211, SerNo: 14593713784084340560457949464740
---> Cfg: Num Interfaces: 2, Identifier: 1, Attributes: 0xa0
    ---> Interface 0
        ---> Alternate settings 0: Num Endpoints: 3, Class and SubClass: (0xff, 0x01), Protocol: 0
            ---> Endpoint 0x01: Direction: Host-To-Dev, Type: Bulk
            ---> Endpoint 0x82: Direction: Dev-To-Host, Type: Bulk
            ---> Endpoint 0x83: Direction: Dev-To-Host, Type: Interrupt
    ---> Interface 1
        ---> Alternate settings 0: Num Endpoints: 0, Class and SubClass: (0xff, 0x05), Protocol: 0
- Device: 045e:0941 <failed to open, on Windows this is because it does not have the WinUSB driver attached>
---> Cfg: Num Interfaces: 1, Identifier: 1, Attributes: 0xe0
    ---> Interface 0
        ---> Alternate settings 0: Num Endpoints: 1, Class and SubClass: (0x09, 0x00), Protocol: 0
            ---> Endpoint 0x83: Direction: Dev-To-Host, Type: Interrupt
- Device: 045e:0922, Microsoft Surface Keyboard, SerNo: None
---> Cfg: Num Interfaces: 1, Identifier: 1, Attributes: 0xe0
    ---> Interface 0
        ---> Alternate settings 0: Num Endpoints: 2, Class and SubClass: (0x03, 0x00), Protocol: 0
            ---> Endpoint 0x81: Direction: Dev-To-Host, Type: Interrupt
            ---> Endpoint 0x02: Direction: Host-To-Dev, Type: Interrupt
```