### PR TITLE
Add `stacklevel=` to `USBContext` deprecation message

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -2100,6 +2100,7 @@ class USBContext:
                         'Use "with USBContext() as context:" for safer cleanup'
                         ' on interpreter shutdown. See also USBContext.open().',
                         DeprecationWarning,
+                        stacklevel=4
                     )
                     self.open()
                 self.__context_refcount += 1


### PR DESCRIPTION
Otherwise the file:line points to within python-libusb1 itself, which is quite useless.