### PR TITLE
Fix incorrect getFinalizer() reference in setPollFDNotifiers()

### DIFF
--- a/usb1/__init__.py
+++ b/usb1/__init__.py
@@ -2603,7 +2603,7 @@ class USBContext(_LibUSB1Finalizer):
             # race-condition) it is not a big deal, as __finalizePollFDNotifiers
             # will do the right thing even if called multiple times in a row.
             self.__has_pollfd_finalizer = True
-            self.getFinalizer(
+            self._getFinalizer(
                 self,
                 self.__finalizePollFDNotifiers, # Note: staticmethod
                 context_p=self.__context_p,


### PR DESCRIPTION
I am going off user logs and guessing here, but it looks to me that when reworking the finalizer and seemingly changing getFinalizer() to be internal, at least one existing reference was missed in the 3.3.0 release.

I did not grep the codebase in case this happens multiple times, nor did I test the change (my system ships older libusb1 at the moment).

Reported downstream here - https://github.com/C0rn3j/sc-controller/issues/72