### PR TITLE
Delete the deprecated libusb1.py

### DIFF
--- a/libusb1.py
+++ b/libusb1.py
@@ -1,8 +1,0 @@
-import warnings
-warnings.warn(
-  'Importing this module should not be needed, everything intended to be '
-  'exposed should be available in usb1 module.',
-  DeprecationWarning,
-)
-del warnings
-from usb1.libusb1 import *


### PR DESCRIPTION
It's' been 10 years since it was deprecated, surely it's not needed anymore.

Note on the series of PRs and a possible future series - I am counting with supporting Python 3.11 at maximum - which is going to be the oldest version supported upstream this October.